### PR TITLE
docs: add 'About this project' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A UNIX shell reimplementation in C. Parses and executes commands with pipes, red
 
 Built with [Ghazaleh Ansari](https://github.com/ghazalehans) as part of the 42 Berlin Common Core.
 
+## About this project
+
+What makes Minishell harder than the sum of its parts is the interplay between subsystems — a pipe setup interacts with signal handling, quote tokenisation interacts with environment-variable expansion, heredoc collection interacts with `SIGINT` during read. Getting each subsystem right in isolation takes a few days; making them all compose without leaks, hangs, or zombie processes is where most of the commits go.
+
+This repo is what we arrived at after that compose-them-all phase: a shell that behaves close to bash for the handled feature set, passes valgrind clean on the paths the 42 subject requires, and whose parser, executor, and signal handlers can be read independently rather than as one tangled file.
+
 ## Features
 
 - Interactive prompt powered by GNU Readline, with history


### PR DESCRIPTION
Docs-only. Adds an 'About this project' section to the README between
the tagline/co-author line and the Features list.

Frames the project around its real engineering theme — subsystem
interplay (pipes × signals × env expansion × heredoc) — rather than
just listing what it does. Complements the existing 'What was
technically hard' section lower down; does not duplicate it.

No code, no Makefile, no CI changes.